### PR TITLE
Fix Language Warp locale leak by spoofing Accept-Language across VPN

### DIFF
--- a/src/pages/background/eventHandlers/registerScripts.ts
+++ b/src/pages/background/eventHandlers/registerScripts.ts
@@ -7,6 +7,12 @@ import { FETCH_SERVER_LIST } from 'state/slices/servers'
 import { ACTIVATE_SPLIT_PERSONALITY } from 'state/slices/splitPersonalityEnabled'
 import { initializeUserAgentsList, setOriginalUserAgent } from 'state/slices/userAgent'
 import {
+  resetSpoofAcceptLanguageHeader,
+  spoofAcceptLanguageHeader,
+} from 'services/declarativeNetRequest/updateDynamicRules'
+import locales from 'utils/locales'
+import { getPrivacyFeatureEnabledDomains } from 'utils/networkSpoofing'
+import {
   languageWarpScriptId,
   locationWarpScriptId,
   splitPersonalityScriptId,
@@ -117,6 +123,10 @@ const registerScripts = async (
     const isTimeZoneWarpActive = store.getState().timeWarpEnabled
     const serverList = store.getState().servers.serverList
     const isUserPro = store.getState().session.sessionData?.is_premium
+    const proxyStatus = store.getState().proxy.status
+    const dontSpoofDomains = getPrivacyFeatureEnabledDomains(store.getState().allowlist)
+    const localeKey = (currentLocation.country_code ?? 'AUTO') as keyof typeof locales
+    const languageWarpLocale = locales[localeKey]?.locale ?? 'en'
 
     const excludeMatchesFromAllowList = transformAllowListToExcludeMatches(
       store.getState().allowlist,
@@ -178,6 +188,7 @@ const registerScripts = async (
     }
 
     if (
+      proxyStatus === 'on' &&
       !autopilot.autopilotSelected &&
       currentLocation.id !== undefined &&
       currentLocation.id !== null &&
@@ -192,6 +203,10 @@ const registerScripts = async (
         ],
         excludeMatchesFromAllowList,
       )
+
+      await spoofAcceptLanguageHeader(languageWarpLocale, dontSpoofDomains)
+    } else {
+      await resetSpoofAcceptLanguageHeader()
     }
 
     if (

--- a/src/services/declarativeNetRequest/updateDynamicRules.ts
+++ b/src/services/declarativeNetRequest/updateDynamicRules.ts
@@ -14,26 +14,28 @@ const {
   OTHER,
 } = chrome.declarativeNetRequest.ResourceType
 
+const spoofableResourceTypes = [
+  MAIN_FRAME,
+  SUB_FRAME,
+  STYLESHEET,
+  SCRIPT,
+  IMAGE,
+  FONT,
+  OBJECT,
+  XMLHTTPREQUEST,
+  PING,
+  CSP_REPORT,
+  MEDIA,
+  WEBSOCKET,
+  OTHER,
+]
+
 // It's just a template of a rule. Spoofed Header value is required to make it finalized.
 const spoofUserAgentHeaderRuleTemplate: chrome.declarativeNetRequest.Rule = {
   id: 1,
   priority: 1,
   condition: {
-    resourceTypes: [
-      MAIN_FRAME,
-      SUB_FRAME,
-      STYLESHEET,
-      SCRIPT,
-      IMAGE,
-      FONT,
-      OBJECT,
-      XMLHTTPREQUEST,
-      PING,
-      CSP_REPORT,
-      MEDIA,
-      WEBSOCKET,
-      OTHER,
-    ],
+    resourceTypes: spoofableResourceTypes,
     urlFilter: '*',
   },
   action: {
@@ -135,6 +137,35 @@ const spoofUserAgentHeaderRuleTemplate: chrome.declarativeNetRequest.Rule = {
   },
 }
 
+const spoofAcceptLanguageHeaderRuleTemplate: chrome.declarativeNetRequest.Rule = {
+  id: 2,
+  priority: 1,
+  condition: {
+    resourceTypes: spoofableResourceTypes,
+    urlFilter: '*',
+  },
+  action: {
+    type: chrome.declarativeNetRequest.RuleActionType.MODIFY_HEADERS,
+    requestHeaders: [
+      {
+        header: 'Accept-Language',
+        operation: chrome.declarativeNetRequest.HeaderOperation.SET,
+      },
+    ],
+  },
+}
+
+const createAcceptLanguageHeaderValue = (locale = 'en'): string => {
+  const normalizedLocale = locale.trim() || 'en'
+  const primaryLanguage = normalizedLocale.split('-')[0]
+
+  if (!primaryLanguage || primaryLanguage === normalizedLocale) {
+    return normalizedLocale
+  }
+
+  return `${normalizedLocale},${primaryLanguage};q=0.9`
+}
+
 export async function spoofUserAgentHeader(
   spoofedUserAgent = '',
   dontSpoofDomains: string[],
@@ -154,5 +185,27 @@ export async function spoofUserAgentHeader(
 export async function resetSpoofUserAgentHeader(): Promise<void> {
   await chrome.declarativeNetRequest.updateDynamicRules({
     removeRuleIds: [spoofUserAgentHeaderRuleTemplate.id],
+  })
+}
+
+export async function spoofAcceptLanguageHeader(
+  locale = 'en',
+  dontSpoofDomains: string[],
+): Promise<void> {
+  const rule = JSON.parse(JSON.stringify(spoofAcceptLanguageHeaderRuleTemplate))
+  rule.action.requestHeaders[0].value = createAcceptLanguageHeaderValue(locale)
+  // requests initiated from these domains will not be spoofed i.e from the page
+  rule.condition.excludedInitiatorDomains = dontSpoofDomains
+  // requests to these domains will not be spoofed
+  rule.condition.excludedRequestDomains = dontSpoofDomains
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    addRules: [rule],
+    removeRuleIds: [spoofAcceptLanguageHeaderRuleTemplate.id],
+  })
+}
+
+export async function resetSpoofAcceptLanguageHeader(): Promise<void> {
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: [spoofAcceptLanguageHeaderRuleTemplate.id],
   })
 }

--- a/src/services/importExport/importPrivacySettings.ts
+++ b/src/services/importExport/importPrivacySettings.ts
@@ -1,6 +1,10 @@
 import { DataCenter, ServerList } from 'api/types'
 import { AddToAllowlistType } from 'components/hooks/useManageAllowlist'
 import { SHA256 } from 'crypto-js'
+import {
+  resetSpoofAcceptLanguageHeader,
+  spoofAcceptLanguageHeader,
+} from 'services/declarativeNetRequest/updateDynamicRules'
 import { pushToDebugLog } from 'services/debugLog'
 import { AppDispatch } from 'state'
 import { setAdPrivacyEnabled } from 'state/slices/adPrivacyEnabled'
@@ -28,6 +32,8 @@ import {
 } from 'utils/constants'
 import { getBundleNamePostFix } from 'utils/getBundleName'
 import { getNearestValidDataCenter } from 'utils/getNearestValidLocation'
+import locales from 'utils/locales'
+import { getPrivacyFeatureEnabledDomains } from 'utils/networkSpoofing'
 import { doesBundleExistInBuild, registerScript, unregisterScript } from 'utils/scriptController'
 import transformAllowListToExcludeMatches from 'utils/transformAllowListToExcludeMatches'
 import { ImportedSettingsV1 } from 'utils/validators'
@@ -40,6 +46,8 @@ type ImportPrivacySettingsArgs = {
   isUserPro: 0 | 1 | undefined
   serverList: ServerList
   existingAllowList: AllowlistState
+  currentLocationCountryCode: string | undefined
+  proxyStatus: string
   dispatch: AppDispatch
   addToAllowlist: AddToAllowlistType
 }
@@ -57,10 +65,19 @@ type ImportLocationWarpArgs = Pick<
 
 type ImportLanguageWarpArgs = Pick<
   ImportPrivacySettingsArgs,
-  'importedSettings' | 'existingAllowList' | 'autopilotSelected' | 'locationId' | 'dispatch'
+  | 'importedSettings'
+  | 'existingAllowList'
+  | 'autopilotSelected'
+  | 'locationId'
+  | 'currentLocationCountryCode'
+  | 'proxyStatus'
+  | 'dispatch'
 >
 
-type ImportTimeZoneWarpArgs = ImportLanguageWarpArgs
+type ImportTimeZoneWarpArgs = Pick<
+  ImportPrivacySettingsArgs,
+  'importedSettings' | 'existingAllowList' | 'autopilotSelected' | 'locationId' | 'dispatch'
+>
 
 const activateLocationWarp = async ({
   autopilotSelected,
@@ -123,6 +140,8 @@ const activateLanguageWarp = async ({
   importedSettings,
   existingAllowList,
   locationId,
+  currentLocationCountryCode,
+  proxyStatus,
   dispatch,
 }: ImportLanguageWarpArgs) => {
   if (
@@ -130,20 +149,35 @@ const activateLanguageWarp = async ({
     importedSettings.languageWarpEnabled !== null
   ) {
     await dispatch(setLanguageWarpEnabled(importedSettings.languageWarpEnabled))
-
-    if (autopilotSelected) return
-    if (locationId === undefined || locationId === null) return
-
     const excludeMatchesFromAllowList = transformAllowListToExcludeMatches(existingAllowList)
+    const dontSpoofDomains = getPrivacyFeatureEnabledDomains(existingAllowList)
+    const localeKey = (currentLocationCountryCode ?? 'AUTO') as keyof typeof locales
+    const languageWarpLocale = locales[localeKey]?.locale ?? 'en'
 
-    if (importedSettings.languageWarpEnabled) {
-      await registerScript(
-        languageWarpScriptId,
-        [SHA256(locationId.toString()) + getBundleNamePostFix('languageWarpScript') + '.bundle.js'],
-        excludeMatchesFromAllowList,
-      )
-    } else {
+    if (!importedSettings.languageWarpEnabled) {
       await unregisterScript(languageWarpScriptId)
+      await resetSpoofAcceptLanguageHeader()
+      return
+    }
+
+    if (autopilotSelected) {
+      await resetSpoofAcceptLanguageHeader()
+      return
+    }
+
+    if (locationId === undefined || locationId === null) {
+      await resetSpoofAcceptLanguageHeader()
+      return
+    }
+
+    await registerScript(
+      languageWarpScriptId,
+      [SHA256(locationId.toString()) + getBundleNamePostFix('languageWarpScript') + '.bundle.js'],
+      excludeMatchesFromAllowList,
+    )
+
+    if (proxyStatus === 'on') {
+      await spoofAcceptLanguageHeader(languageWarpLocale, dontSpoofDomains)
     }
   }
 }
@@ -178,10 +212,12 @@ const activateTimeZoneWarp = async ({
 export const importPrivacySettings = async ({
   autopilotSelected,
   currentDataCenter,
+  currentLocationCountryCode,
   importedSettings,
   isUserPro,
   locationId,
   existingAllowList,
+  proxyStatus,
   serverList,
   dispatch,
 }: ImportPrivacySettingsArgs): Promise<void> => {
@@ -197,9 +233,11 @@ export const importPrivacySettings = async ({
 
   await activateLanguageWarp({
     autopilotSelected,
+    currentLocationCountryCode,
     existingAllowList,
     importedSettings,
     locationId,
+    proxyStatus,
     dispatch,
   })
 

--- a/src/services/importExport/importSettings.ts
+++ b/src/services/importExport/importSettings.ts
@@ -21,6 +21,8 @@ type ImportSettingsArgs = {
   favoriteLocations: FavoriteLocationsState
   dispatch: AppDispatch
   locationId: number | undefined
+  currentLocationCountryCode: string | undefined
+  proxyStatus: string
   currentDataCenter: Partial<DataCenter>
   autopilotSelected: boolean
   isUserPro: 0 | 1 | undefined
@@ -36,6 +38,8 @@ export const importSettings = async ({
   favoriteLocations,
   dispatch,
   locationId,
+  currentLocationCountryCode,
+  proxyStatus,
   currentDataCenter,
   autopilotSelected,
   isUserPro,
@@ -64,11 +68,13 @@ export const importSettings = async ({
       addToAllowlist,
       autopilotSelected,
       currentDataCenter,
+      currentLocationCountryCode,
       dispatch,
       existingAllowList,
       importedSettings,
       isUserPro,
       locationId,
+      proxyStatus,
       serverList,
     })
 

--- a/src/services/proxyConfig/proxyConfig.ts
+++ b/src/services/proxyConfig/proxyConfig.ts
@@ -26,12 +26,18 @@ import { setCurrentDataCenter } from 'state/slices/currentDataCenter'
 import proxyOffIcon from 'assets/img/proxyOff.png'
 import proxyOnIcon from 'assets/img/proxyOn.png'
 import { pushToDebugLog } from 'services/debugLog'
+import locales from 'utils/locales'
 
 import transformAllowListToExcludeMatches from 'utils/transformAllowListToExcludeMatches'
 import { doesBundleExistInBuild, registerScript, unregisterScript } from 'utils/scriptController'
+import {
+  resetSpoofAcceptLanguageHeader,
+  spoofAcceptLanguageHeader,
+} from 'services/declarativeNetRequest/updateDynamicRules'
 import { SHA256 } from 'crypto-js'
 import { getBundleNamePostFix } from 'utils/getBundleName'
 import { getNearestValidDataCenter } from 'utils/getNearestValidLocation'
+import { getPrivacyFeatureEnabledDomains } from 'utils/networkSpoofing'
 import shuffle from 'lodash.shuffle'
 import { NO_IP } from 'services/proxyAuth/checkIp'
 import { serializeError } from 'serialize-error'
@@ -252,10 +258,14 @@ export const connect = async (
 
     const proxyStatus = getState().proxy.status
     const isAutoPilot = getState().autopilot.autopilotSelected
+    const currentLocation = getState().currentLocation
     const currentLocationId = getState().currentLocation.id
     const allowList = getState().allowlist
     const excludeMatchesFromAllowList = transformAllowListToExcludeMatches(allowList)
     const isLanguageWarpActive = getState().languageWarpEnabled
+    const dontSpoofDomains = getPrivacyFeatureEnabledDomains(allowList)
+    const localeKey = (currentLocation.country_code ?? 'AUTO') as keyof typeof locales
+    const languageWarpLocale = locales[localeKey]?.locale ?? 'en'
     const currentDataCenter = getState().currentDataCenter
     const currentDataCenterId = currentDataCenter.id
     const isLocationWarpActive = getState().locationWarp
@@ -281,9 +291,17 @@ export const connect = async (
           ],
           excludeMatchesFromAllowList,
         )
+
+        await spoofAcceptLanguageHeader(languageWarpLocale, dontSpoofDomains)
+      } else {
+        await resetSpoofAcceptLanguageHeader()
       }
-    } else if (isAutoPilot) {
-      await unregisterScript(languageWarpScriptId)
+    } else {
+      await resetSpoofAcceptLanguageHeader()
+
+      if (isAutoPilot) {
+        await unregisterScript(languageWarpScriptId)
+      }
     }
 
     if (
@@ -427,6 +445,7 @@ export const disconnect = async (
     await unregisterScript(languageWarpScriptId)
     await unregisterScript(locationWarpScriptId)
     await unregisterScript(timeZoneWarpScriptId)
+    await resetSpoofAcceptLanguageHeader()
   }
 }
 

--- a/src/state/slices/session.ts
+++ b/src/state/slices/session.ts
@@ -37,7 +37,10 @@ import { fetchNotifications } from 'state/slices/newsfeed'
 import { refreshFavorites } from './favoriteLocations'
 import { unregisterScript } from 'utils/scriptController'
 import { setIsRightAfterLogin } from './isRightAfterLogin'
-import { resetSpoofUserAgentHeader } from 'services/declarativeNetRequest/updateDynamicRules'
+import {
+  resetSpoofAcceptLanguageHeader,
+  resetSpoofUserAgentHeader,
+} from 'services/declarativeNetRequest/updateDynamicRules'
 import { pushToDebugLog } from 'services/debugLog'
 import { activateSplitPersonality } from './splitPersonalityEnabled'
 import { setAdPrivacyEnabled } from './adPrivacyEnabled'
@@ -134,6 +137,7 @@ export const logout = createAsyncThunk(LOGOUT, async (_, { getState, dispatch })
     await unregisterScript(languageWarpScriptId)
     await unregisterScript(timeZoneWarpScriptId)
     await resetSpoofUserAgentHeader()
+    await resetSpoofAcceptLanguageHeader()
   }
 
   await Promise.all([sendLogoutRequest(), resetState()])

--- a/src/views/General/General.tsx
+++ b/src/views/General/General.tsx
@@ -46,6 +46,7 @@ const General: ThemeUiElement = () => {
   const autopilot = useSelector(s => s.autopilot)
   const currentDataCenter = useSelector(s => s.currentDataCenter)
   const currentLocation = useSelector(s => s.currentLocation)
+  const proxyStatus = useSelector(s => s.proxy.status)
 
   const isUserPro = useSelector(s => s.session.sessionData?.is_premium)
 
@@ -97,7 +98,9 @@ const General: ThemeUiElement = () => {
         autopilotSelected: autopilot.autopilotSelected,
         isUserPro: isUserPro,
         currentDataCenter,
+        currentLocationCountryCode: currentLocation.country_code,
         locationId: currentLocation.id,
+        proxyStatus,
         isSplitPersonalityEnabled,
         spoofedUserAgent,
       })

--- a/src/views/Privacy/Privacy.tsx
+++ b/src/views/Privacy/Privacy.tsx
@@ -16,6 +16,7 @@ import { setWorkerBlock } from 'state/slices/workerBlock'
 import { setAdPrivacyEnabled } from 'state/slices/adPrivacyEnabled'
 import ToolTip from 'components/ToolTip'
 import getTimeZoneInfo from 'utils/getTimeZoneInfo'
+import locales from 'utils/locales'
 
 import DoNotDisturbIcon from 'assets/img/doNotDisturb.svg'
 import WebRtcLeakIcon from 'assets/img/webRtcLeak.svg'
@@ -42,6 +43,11 @@ import { getNearestValidDataCenter } from 'utils/getNearestValidLocation'
 import { pushToDebugLog } from 'services/debugLog'
 import { addOverlay } from 'state/slices/overlay'
 import { useState } from 'react'
+import {
+  resetSpoofAcceptLanguageHeader,
+  spoofAcceptLanguageHeader,
+} from 'services/declarativeNetRequest/updateDynamicRules'
+import { getPrivacyFeatureEnabledDomains } from 'utils/networkSpoofing'
 
 const Privacy: ThemeUiElement = () => {
   const dispatch = useDispatch()
@@ -63,6 +69,7 @@ const Privacy: ThemeUiElement = () => {
   const serverList = useSelector(s => s.servers.serverList)
   const isUserPro = useSelector(s => s.session.sessionData?.is_premium)
   const spoofedUserAgent = useSelector(s => s.userAgent.spoofed)
+  const proxyStatus = useSelector(s => s.proxy.status)
 
   const [shouldShowReloadAlert, showReloadAlert] = useState(false)
 
@@ -274,6 +281,9 @@ const Privacy: ThemeUiElement = () => {
               if (locationId === undefined || locationId === null) return
 
               const excludeMatchesFromAllowList = transformAllowListToExcludeMatches(allowList)
+              const dontSpoofDomains = getPrivacyFeatureEnabledDomains(allowList)
+              const localeKey = (currentLocation.country_code ?? 'AUTO') as keyof typeof locales
+              const languageWarpLocale = locales[localeKey]?.locale ?? 'en'
 
               if (isLanguageWarpActive) {
                 await registerScript(
@@ -285,8 +295,13 @@ const Privacy: ThemeUiElement = () => {
                   ],
                   excludeMatchesFromAllowList,
                 )
+
+                if (proxyStatus === 'on') {
+                  await spoofAcceptLanguageHeader(languageWarpLocale, dontSpoofDomains)
+                }
               } else {
                 await unregisterScript(languageWarpScriptId)
+                await resetSpoofAcceptLanguageHeader()
               }
             }}
             checked={languageWarpEnabled}


### PR DESCRIPTION
This PR fixes a privacy leak where Language Warp updated browser locale APIs but did not consistently spoof the HTTP `Accept-Language` header, leading to a location expose of the user's country.

#### What changed
- Added declarativeNetRequest support for `Accept-Language` spoofing (`set` + reset).
- Derived spoofed language from connected location locale mapping (with fallback).
- Applied/reset header spoofing in all relevant flows:
  - connect / disconnect
  - Language Warp toggle
  - background script registration
  - imported privacy settings
  - logout cleanup
- Preserved allowlist exclusions so opted-out domains are not spoofed.

#### Why
Users could still be fingerprinted by real language preferences in request headers even when Language Warp was enabled.

#### Before
<img width="763" height="48" alt="msedge_02PtGtW9Ms" src="https://github.com/user-attachments/assets/95b8b6e8-b854-4c72-bbd4-50b6ecc8d940" />

#### After
<img width="805" height="45" alt="msedge_3uV95WtVUJ" src="https://github.com/user-attachments/assets/1e2129f7-799b-4f63-9be9-9dcbfc027535" /> 

Typecheck passes: `yarn tsc --noEmit`.